### PR TITLE
chore: pin GitHub Actions uses: references to commit SHA instead of tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Python
-        uses: actions/setup-python@v7.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.8"
       - name: Configure pip caching
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 ﻿# Changelog
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 <!--
 Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 -->
 
 ## [Unreleased]
 ### Security
+- TBD - to be finalized after review
 ### Added
 ### Fixed
 - Fixed YAML linting errors in build.yml: added document start marker, corrected indentation, removed extra whitespace, quoted python-version, reordered step fields, added shell: bash to all run steps, and updated action versions to specific release tags
 ### Changed
+### Deprecated
 ### Removed
 ### Deployment Changes
 <!--

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Please ADD ALL Changes to the UNRELASED SECTION and not a specific release
 
 ## [Unreleased]
 ### Security
-- TBD - to be finalized after review
+- Pinned GitHub Actions used in build.yml (actions/checkout, actions/setup-python, actions/cache) to immutable commit SHAs instead of mutable version tags, preventing a repointed or compromised tag from silently running different code
 ### Added
 ### Fixed
 - Fixed YAML linting errors in build.yml: added document start marker, corrected indentation, removed extra whitespace, quoted python-version, reordered step fields, added shell: bash to all run steps, and updated action versions to specific release tags


### PR DESCRIPTION
## Summary

Pins GitHub Actions `uses:` references in `.github/workflows/build.yml` to full commit SHAs instead of mutable tags, per GitHub's recommended hardening practice. A tag can be repointed by the upstream maintainer or an attacker who compromises their account; a commit SHA is immutable.

This PR currently contains only a placeholder CHANGELOG.md entry; the actual pinning changes follow in subsequent commits.

## Changes planned
- `actions/checkout@v7.0.1` -> pinned SHA (`# v7.0.1` comment retained)
- `actions/setup-python@v7.0.0` -> pinned SHA (`# v7.0.0` comment retained)
- `actions/cache@v6.1.0` -> pinned SHA (`# v6.1.0` comment retained)

Each SHA will be independently verified against its upstream tag (`git ls-remote`) before being committed.

Closes #417